### PR TITLE
Introduce an MPI crate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ priority-queue = "1.3.1"                                   # for prims algorithm
 blossom = "0.4.0"                                          # for the blossom algorithm
 nalgebra = {version = "0.32", features = ["rayon"]}        # for fast matrices
 lazy_static = "1.4.0"
+mpi = {version = "0.6", optional = true}                   # for MPI crate feature
 
 [dev-dependencies]
 approx = "0.5.1"                # for assertions with float values

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,5 +102,6 @@ pub enum Parallelism {
     /// Run in multiple threads on a single node
     MultiThreaded,
     /// Run on multiple nodes. Requires MPI.
+    #[cfg(feature = "mpi")]
     MPI,
 }

--- a/src/computation_mode.rs
+++ b/src/computation_mode.rs
@@ -10,6 +10,7 @@ pub const SEQ_COMPUTATION: usize = 0;
 pub const PAR_COMPUTATION: usize = 1;
 
 /// use multiple machinges to parallelize computation, via MPI
+#[cfg(feature = "mpi")]
 pub const MPI_COMPUTATION: usize = 2;
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ fn approx_run(
                 Parallelism::MultiThreaded => {
                     christofides::<{ computation_mode::PAR_COMPUTATION }>(&tsp_instance.graph)
                 }
+                #[cfg(feature = "mpi")]
                 Parallelism::MPI => {
                     christofides::<{ computation_mode::MPI_COMPUTATION }>(&tsp_instance.graph)
                 }
@@ -105,6 +106,7 @@ fn mst_run(
                 prim::<{ computation_mode::SEQ_COMPUTATION }>(&na_matrix)
             }
             Parallelism::MultiThreaded => prim::<{ computation_mode::PAR_COMPUTATION }>(&na_matrix),
+            #[cfg(feature = "mpi")]
             Parallelism::MPI => prim::<{ computation_mode::MPI_COMPUTATION }>(&na_matrix),
         },
     };
@@ -130,6 +132,7 @@ fn lower_bound_run(
                 Parallelism::MultiThreaded => {
                     one_tree_lower_bound::<{ computation_mode::PAR_COMPUTATION }>(&na_matrix)
                 }
+                #[cfg(feature = "mpi")]
                 Parallelism::MPI => {
                     one_tree_lower_bound::<{ computation_mode::MPI_COMPUTATION }>(&na_matrix)
                 }

--- a/src/mst.rs
+++ b/src/mst.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    computation_mode::{MPI_COMPUTATION, PAR_COMPUTATION, SEQ_COMPUTATION},
+    computation_mode::*,
     datastructures::{AdjacencyMatrix, Edge, Graph, NAMatrix},
 };
 
@@ -26,8 +26,9 @@ pub fn prim<const MODE: usize>(graph: &NAMatrix) -> Graph {
     match MODE {
         SEQ_COMPUTATION => prim_with_excluded_node_single_threaded(graph, graph.dim()),
         PAR_COMPUTATION => prim_with_excluded_node_multi_threaded(graph, graph.dim()),
+        #[cfg(feature = "mpi")]
         MPI_COMPUTATION => todo!(),
-        _ => panic!("Unsupported value of the constant parameter Mode: {}", MODE),
+        _ => panic_on_invaid_mode::<MODE>(),
     }
 }
 

--- a/src/one_tree.rs
+++ b/src/one_tree.rs
@@ -68,6 +68,7 @@ pub fn one_tree_lower_bound<const MODE: usize>(graph: &NAMatrix) -> f64 {
     match MODE {
         computation_mode::SEQ_COMPUTATION => one_tree_lower_bound_seq(graph),
         computation_mode::PAR_COMPUTATION => todo!(),
+        #[cfg(feature = "mpi")]
         computation_mode::MPI_COMPUTATION => todo!(),
         _ => computation_mode::panic_on_invaid_mode::<MODE>(),
     }

--- a/src/solvers/approximate/christofides.rs
+++ b/src/solvers/approximate/christofides.rs
@@ -232,6 +232,7 @@ fn fill_multigraph_with_mst_and_matching<const MODE: usize>(
                         .for_each(|&Edge { to, cost }| neighbours_vec[(to, 0)] = (cost, 1))
                 });
         }
+        #[cfg(feature = "mpi")]
         MPI_COMPUTATION => todo!(),
         _ => panic_on_invaid_mode::<MODE>(),
     }
@@ -259,6 +260,7 @@ fn fill_multigraph_with_mst_and_matching<const MODE: usize>(
                 })
             }
         }
+        #[cfg(feature = "mpi")]
         MPI_COMPUTATION => todo!(),
         _ => panic_on_invaid_mode::<MODE>(),
     }


### PR DESCRIPTION
make all the MPI stuff available under an optional crate feature,
to not necessarily depend on MPI on all platforms