### PR TITLE
Always build with target-cpu=native

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+# always build for the host CPU, this optimizes performance
+rustflags = ["-Ctarget-cpu=native"]


### PR DESCRIPTION
I propose, that we always build for the native CPU.