### PR TITLE
improve naming: move from euclidean graph to metric graph

### DIFF
--- a/src/datastructures/mod.rs
+++ b/src/datastructures/mod.rs
@@ -45,7 +45,7 @@ pub trait AdjacencyMatrix {
 
     /// checks, if the triangle inequality holds:
     /// `cost(i,j) <= cost(i,k) + cost(k,j)` for all i,j,k
-    fn is_euclidean(&self) -> bool {
+    fn is_metric(&self) -> bool {
         let dim = self.dim();
         for i in 0..dim {
             for j in i..dim {

--- a/src/solvers/approximate/christofides.rs
+++ b/src/solvers/approximate/christofides.rs
@@ -60,8 +60,8 @@ pub fn christofides_generic<const MODE: usize>(
 
     // validate that the triangle ineq. holds
     debug_assert!(
-        graph_matr.is_euclidean(),
-        "The given Graph is not euclidean, but Christofides Algorithm
+        graph_matr.is_metric(),
+        "The given Graph is not metric, but Christofides Algorithm
     // requires the triangle inequality"
     );
 
@@ -222,7 +222,7 @@ fn find_cycle(
     cycle
 }
 
-/// assumption: the underlying graph is complete and euclidean
+/// assumption: the underlying graph is complete and metric (the triangle inequality holds)
 ///
 /// computes from an euclidean cycle the hamiltonian cycle, by skipping
 /// already visited vertices
@@ -676,7 +676,7 @@ mod test {
         assert_eq!(expected, euler_cycle);
     }
 
-    /// euclidean graph:
+    /// metric graph:
     /// 0-----1
     /// |\   /|
     /// | \ / |


### PR DESCRIPTION
christofides algorithm only requires the triangle inequality, not that the graph can be embedded into euclidean space