### PR TITLE
resolve #30

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ fn approx_run(
                             &mut tries,
                             &graph,
                         );
-                        mpi_improve_matching(&graph, matching.as_mut_slice(), tries);
+                        mpi_improve_matching(&graph, matching.as_mut_slice(), tries, world);
                         // non-root process is done here
                         return Ok(());
                     }

--- a/src/solvers/approximate/christofides.rs
+++ b/src/solvers/approximate/christofides.rs
@@ -46,11 +46,6 @@ pub fn christofides_exact<const MODE: usize>(graph: &Graph) -> Solution {
 /// The algorithm should be performant, therefore instead of the generic [`crate::datastructures::AdjacencyMatrix`]
 /// trait,
 /// the type [`NAMatrix`] is used.
-///
-/// When `MODE == MPI_COMPUTATION`, then the function expects that
-/// [mpi::initialize](https://rsmpi.github.io/rsmpi/mpi/fn.initialize.html) has been
-/// called before, and that the result of the MPI initialization will not be dropped until the
-/// function is finished. See als [this issue](https://github.com/lquenti/walky/issues/30)
 pub fn christofides_generic<const MODE: usize>(
     graph: &Graph,
     matching_computer: fn(&Graph, &NAMatrix) -> Vec<[usize; 2]>,


### PR DESCRIPTION
This should make it possible to call Christofides algorithm in an uninitialized or an initialized MPI context without errors.
This resolves #30